### PR TITLE
Plamen5kov/enable tgz versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        // classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+		classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/widgets/build.gradle
+++ b/widgets/build.gradle
@@ -1,3 +1,7 @@
+import groovy.json.JsonSlurper //used to parse package.json
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput
+
 def isWinOs = System.properties['os.name'].toLowerCase().contains('windows')
 
 apply plugin: 'com.android.library'
@@ -57,6 +61,16 @@ task cleanDistDir (type: Delete) {
 	delete "../dist/"
 }
 
+task fixVersion << {
+	if(project.hasProperty("PACKAGE_VERSION")) {
+		def inputFile = new File("./package.json")
+		def json = new JsonSlurper().parseText(inputFile.text)
+		json.version = json.version + "-" + PACKAGE_VERSION
+		def jb = new JsonBuilder(json);
+		inputFile.text = JsonOutput.prettyPrint(jb.toString())
+	}
+}
+
 task copyAar << {
 	copy {
 		from "../package.json"
@@ -65,6 +79,15 @@ task copyAar << {
 	copy {
 		from "build/outputs/aar/widgets-release.aar"
 		into "../dist/platforms/android/"
+	}
+}
+
+task revertPackageJson (type: Exec) {
+	if(isWinOs) {
+		commandLine "cmd", "/c", "git", "checkout", "--", "../package.json"
+	}
+	else {
+		commandLine "git", "checkout", "--", "../package.json"
 	}
 }
 
@@ -79,6 +102,9 @@ task packFramework (type: Exec) {
 	}
 }
 
+
 assembleRelease.dependsOn(cleanDistDir)
-copyAar.dependsOn(assembleRelease)
-packFramework.dependsOn(copyAar)
+fixVersion.dependsOn(assembleRelease)
+copyAar.dependsOn(fixVersion)
+revertPackageJson.dependsOn(copyAar)
+packFramework.dependsOn(revertPackageJson)


### PR DESCRIPTION
- enabled widgets tgz versioning from enviroment variable
- changed gradle build tools version because of error on the `gradle:2.0.0-alpha3` version

ping: @hshristov @vchimev 
