### PR TITLE
Correctly resolve HTTP headers with multiple values on Android.

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -138,11 +138,11 @@ public class Async
 					return;
 				}
 
-				for (int i = 0; i < size - 1; i++)
-				{
-					String key = connection.getHeaderFieldKey(i);
-					String value = connection.getHeaderField(key);
-					this.headers.add(new KeyValuePair(key, value));
+				for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
+					String key = entry.getKey();
+					for (String value: entry.getValue()) {
+						this.headers.add(new KeyValuePair(key, value));
+					}
 				}
 			}
 


### PR DESCRIPTION
No longer clobbering one of the values if the server set a HTTP header
multiple times e.g.:

Header1: value-one
Header1: value-two

Fixes NativeScript/NativeScript#2413
