### PR TITLE
Fix Async.Http HEAD and DELETE on Android

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -41,6 +41,7 @@ public class Async
 	{
 		private static final String DeleteMethod = "DELETE";
 		private static final String GetMethod = "GET";
+        private static final String HeadMethod = "HEAD";
 		private static CookieManager cookieManager;
 
 		public static class KeyValuePair
@@ -300,7 +301,10 @@ public class Async
 
 					// build the result
 					result.getHeaders(connection);
-					result.readResponseStream(connection, openedStreams, options);
+					if (!requestMethod.equals(HeadMethod))
+                    {
+						result.readResponseStream(connection, openedStreams, options);
+					}
 
 					// close the opened streams (saves copy-paste implementation
 					// in each method that throws IOException)

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -39,9 +39,9 @@ public class Async
 
 	public static class Http
 	{
-		private static final String DeleteMethod = "DELETE";
-		private static final String GetMethod = "GET";
-        private static final String HeadMethod = "HEAD";
+		private static final String DELETE_METHOD = "DELETE";
+		private static final String GET_METHOD = "GET";
+        private static final String HEAD_METHOD = "HEAD";
 		private static CookieManager cookieManager;
 
 		public static class KeyValuePair
@@ -275,7 +275,7 @@ public class Async
 					HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
 					// set the request method
-					String requestMethod = options.method != null ? options.method.toUpperCase(Locale.ENGLISH) : GetMethod;
+					String requestMethod = options.method != null ? options.method.toUpperCase(Locale.ENGLISH) : GET_METHOD;
 					connection.setRequestMethod(requestMethod);
 
 					// add the headers
@@ -288,7 +288,7 @@ public class Async
 					}
 
 					// Do not attempt to write the content (body) for DELETE method, Java will throw directly
-					if (!requestMethod.equals(DeleteMethod))
+					if (!requestMethod.equals(DELETE_METHOD))
 					{
 						options.writeContent(connection, openedStreams);
 					}
@@ -301,7 +301,7 @@ public class Async
 
 					// build the result
 					result.getHeaders(connection);
-					if (!requestMethod.equals(HeadMethod))
+					if (!requestMethod.equals(HEAD_METHOD))
                     {
 						result.readResponseStream(connection, openedStreams, options);
 					}

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -41,7 +41,7 @@ public class Async
 	{
 		private static final String DELETE_METHOD = "DELETE";
 		private static final String GET_METHOD = "GET";
-        private static final String HEAD_METHOD = "HEAD";
+		private static final String HEAD_METHOD = "HEAD";
 		private static CookieManager cookieManager;
 
 		public static class KeyValuePair
@@ -302,7 +302,7 @@ public class Async
 					// build the result
 					result.getHeaders(connection);
 					if (!requestMethod.equals(HEAD_METHOD))
-                    {
+					{
 						result.readResponseStream(connection, openedStreams, options);
 					}
 

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -288,7 +288,7 @@ public class Async
 					}
 
 					// Do not attempt to write the content (body) for DELETE method, Java will throw directly
-					if (requestMethod != DeleteMethod)
+					if (!requestMethod.equals(DeleteMethod))
 					{
 						options.writeContent(connection, openedStreams);
 					}


### PR DESCRIPTION
### Fixed a few bugs with HEAD and DELETE method calls in Async.Http for Android.
- HEAD method did not work, because it tried to allocate a buffer the size of Content-Length, even though we had no intention of reading it.
- DELETE method did not work, because it compared the method string by reference.
- Also changed the static final variables to follow Java naming conventions.

Simple example to reproduce HEAD bug on Android:

```
Http.RequestOptions opts = new Http.RequestOptions();
opts.method = "HEAD";
opts.url = "http://ipv4.download.thinkbroadband.com/1GB.zip";
Http.MakeRequest(opts, myCompleteCallback, getApplicationContext());
```

Throws OutOfMemoryError like this: http://pastebin.com/GFkT1Nx9

**Side-note:** Shouldn't there be a separate way to download a file and skip allocating this huge buffer and all the byte array conversion, if the user just wants to download to a file. Would be nice not to limit the downloadable file size to the amount of RAM on the device.
