### PR TITLE
Override getPadding method to calculate padding based on border widths

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/BorderDrawable.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/BorderDrawable.java
@@ -268,6 +268,13 @@ public class BorderDrawable extends ColorDrawable {
         this.backgroundSizeParsedCSSValues = backgroundSizeParsedCSSValues;
 
         this.invalidateSelf();
+    }    
+
+    @Override
+    public boolean getPadding(Rect padding) {
+        padding.set((int)this.borderLeftWidth, (int)this.borderTopWidth, (int)this.borderRightWidth, (int)this.borderBottomWidth);
+
+        return this.borderLeftWidth != 0 && this.borderTopWidth != 0 && this.borderRightWidth != 0 && this.borderBottomWidth != 0;
     }
 
     @Override


### PR DESCRIPTION
GetPadding of BorderDrawable will calculate the paddings based on the corresponding border widths - left, top, bottom, and right.
