### PR TITLE
Image cache won't work if FileSystem is in read-only mode.

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Image/Cache.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Image/Cache.java
@@ -142,6 +142,12 @@ public class Cache {
                     return bitmapSize == 0 ? 1 : bitmapSize;
                 }
             };
+        } else {
+            clearCache();
+            if (mReusableBitmaps != null) {
+                mReusableBitmaps.clear();
+                mReusableBitmaps = null;
+            }
         }
     }
 
@@ -236,6 +242,7 @@ public class Cache {
                 Log.v(TAG, "Memory cache cleared");
             }
         }
+        mMemoryCache = null;
     }
 
     /**
@@ -245,18 +252,6 @@ public class Cache {
         public int memCacheSize = DEFAULT_MEM_CACHE_SIZE;
         public boolean memoryCacheEnabled = DEFAULT_MEM_CACHE_ENABLED;
         public boolean diskCacheEnabled = DEFAULT_DISK_CACHE_ENABLED;
-
-        /**
-         * Create a set of image cache parameters that can be provided to
-         * {@link Cache#getInstance(CacheParams)}.
-         *
-         * @param context                A context to use.
-         * @param diskCacheDirectoryName A unique subdirectory name that will be appended to the
-         *                               application cache directory. Usually "cache" or "images"
-         *                               is sufficient.
-         */
-        public CacheParams(Context context, String diskCacheDirectoryName) {
-        }
 
         /**
          * Sets the memory cache size based on a percentage of the max available VM memory.

--- a/android/widgets/src/main/java/org/nativescript/widgets/ViewHelper.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/ViewHelper.java
@@ -373,5 +373,21 @@ public class ViewHelper {
                 view.setZ(value);
             }
         }
+
+        @TargetApi(21)
+        public static float getLetterspacing(android.widget.TextView textView) {
+            if (ViewHelper.version >= 21) {
+                return textView.getLetterSpacing();
+            }
+
+            return 0;
+        }
+
+        @TargetApi(21)
+        public static void setLetterspacing(android.widget.TextView textView, float value) {
+            if (ViewHelper.version >= 21) {
+                textView.setLetterSpacing(value);
+            }
+        }
 }
     

--- a/build.android.sh
+++ b/build.android.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+echo "Set exit on simple errors"
+set -e
+
+echo "Use dumb gradle terminal"
+export TERM=dumb
+
+echo "Clean dist"
+rm -rf dist
+mkdir dist
+mkdir dist/package
+mkdir dist/package/platforms
+
+echo "Build android"
+mkdir dist/package/platforms/android
+cd android
+./gradlew assembleRelease
+cd ..
+cp android/widgets/build/outputs/aar/widgets-release.aar dist/package/platforms/android/widgets-release.aar
+
+echo "Copy NPM artefacts"
+cp LICENSE dist/package/LICENSE
+cp LICENSE.md dist/package/LICENSE.md
+cp README.md dist/package/README.md
+cp package.json dist/package/package.json
+if [ "$1" ]
+then
+  echo "Suffix package.json's version with tag: $1"
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+fi
+
+echo "NPM pack"
+cd dist/package
+PACKAGE="$(npm pack)"
+cd ../..
+mv dist/package/$PACKAGE dist/$PACKAGE
+echo "Output: dist/$PACKAGE"
+

--- a/build.ios.sh
+++ b/build.ios.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+echo "Set exit on simple errors"
+set -e
+
+echo "Use dumb gradle terminal"
+export TERM=dumb
+
+echo "Clean dist"
+rm -rf dist
+mkdir dist
+mkdir dist/package
+mkdir dist/package/platforms
+
+echo "Build ios"
+mkdir dist/package/platforms/ios
+cd ios
+./build.sh
+cd ..
+cp -r ios/TNSWidgets/build/TNSWidgets.framework dist/package/platforms/ios/TNSWidgets.framework
+
+echo "Copy NPM artefacts"
+cp LICENSE dist/package/LICENSE
+cp LICENSE.md dist/package/LICENSE.md
+cp README.md dist/package/README.md
+cp package.json dist/package/package.json
+if [ "$1" ]
+then
+  echo "Suffix package.json's version with tag: $1"
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+fi
+
+echo "NPM pack"
+cd dist/package
+PACKAGE="$(npm pack)"
+cd ../..
+mv dist/package/$PACKAGE dist/$PACKAGE
+echo "Output: dist/$PACKAGE"
+


### PR DESCRIPTION
ImageView will remove its bitmap when not in visual tree and apply it back once shown.
ImageView add setUri method.
ViewHelper added new method for API 21.