### PR TITLE
Fix for ImageResizer crashing application when a badimage is fetched

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Image/Resizer.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Image/Resizer.java
@@ -147,7 +147,18 @@ public abstract class Resizer extends Worker {
             addInBitmapOptions(options, cache);
         }
 
-        return BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
+        Bitmap results = null;
+        try {
+            // This can throw an error on a corrupted image when using an inBitmap
+            results = BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
+        }
+        catch (Exception e) {
+           // clear the inBitmap and try again
+           options.inBitmap = null;
+           results = BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
+           // If image is broken, rather than an issue with the inBitmap, we will get a NULL out in this case...
+        }
+        return results;
     }
 
     public static Bitmap decodeSampledBitmapFromByteArray(


### PR DESCRIPTION

 See thread at: https://github.com/NativeScript/NativeScript/issues/3169

Basically a bad image will cause the whole application to crash out with this:

> An uncaught Exception occurred on "AsyncTask #2" thread.
> java.lang.RuntimeException: An error occured while executing doInBackground()
> at org.nativescript.widgets.image.AsyncTask$3.done(AsyncTask.java:326)
> at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
> at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
> at java.util.concurrent.FutureTask.run(FutureTask.java:242)
> at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
> at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
> at java.lang.Thread.run(Thread.java:841)
> Caused by: java.lang.IllegalArgumentException: Problem decoding into existing bitmap
> at android.graphics.BitmapFactory.decodeFileDescriptor(BitmapFactory.java:670)
> at org.nativescript.widgets.image.Resizer.decodeSampledBitmapFromDescriptor(Resizer.java:150)
> at org.nativescript.widgets.image.Fetcher.processHttp(Fetcher.java:214)
> at org.nativescript.widgets.image.Fetcher.processBitmap(Fetcher.java

The key error in the call stack is this: `Caused by: java.lang.IllegalArgumentException: Problem decoding into existing bitmap` 