### PR TITLE
Add 'url' and 'statusText' to Async.RequestResult

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -347,6 +347,8 @@ public class Async
 			public String responseAsString;
 			public Bitmap responseAsImage;
 			public Exception error;
+			public String url;
+			public String statusText;
 
 			public void getHeaders(HttpURLConnection connection)
 			{
@@ -542,6 +544,8 @@ public class Async
 
 					// build the result
 					result.getHeaders(connection);
+					result.url = options.url;
+					result.statusText = connection.getResponseMessage();
 					if (!requestMethod.equals(HEAD_METHOD))
 					{
 						result.readResponseStream(connection, openedStreams, options);


### PR DESCRIPTION
Added `url` and `statusText` properties to `Async.RequestResult` class. 

The new properties are used when building a [Response](https://chromedevtools.github.io/debugger-protocol-viewer/tot/Network/#type-Response) object that is sent to the Chrome DevTools's Frontend to visualize a completed network request.