### PR TITLE
ImageCahe now have counter that keeps reference how many times a bitm…

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Image/Worker.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Image/Worker.java
@@ -77,6 +77,12 @@ public abstract class Worker {
         }
     }
 
+    public void removeBitmap(String uri) {
+        if (mCache != null) {
+            mCache.reduceDisplayedCounter(uri);
+        }
+    }
+
     /**
      * Load an image specified by the data parameter into an ImageView (override
      * {@link Worker#processBitmap(String, int, int, boolean)} to define the processing logic). A memory and
@@ -280,9 +286,8 @@ public abstract class Worker {
          */
         @Override
         protected Bitmap doInBackground(Void... params) {
-            final String dataString = String.valueOf(mUri);
             if (debuggable > 0) {
-                Log.v(TAG, "doInBackground - starting work: " + imageViewReference.get() + ", on: " + dataString);
+                Log.v(TAG, "doInBackground - starting work: " + imageViewReference.get() + ", on: " + mUri);
             }
 
 
@@ -313,9 +318,9 @@ public abstract class Worker {
             if (bitmap != null) {
                 if (mCache != null && mCacheImage) {
                     if (debuggable > 0) {
-                        Log.v(TAG, "addBitmapToCache: " + imageViewReference.get() + ", src: " + dataString);
+                        Log.v(TAG, "addBitmapToCache: " + imageViewReference.get() + ", src: " + mUri);
                     }
-                    mCache.addBitmapToCache(dataString, bitmap);
+                    mCache.addBitmapToCache(mUri, bitmap);
                 }
             }
 

--- a/android/widgets/src/main/java/org/nativescript/widgets/ImageView.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/ImageView.java
@@ -169,7 +169,7 @@ public class ImageView extends android.widget.ImageView implements BitmapOwner {
         mAsync = async;
 
         // Clear current bitmap only if we set empty URI.
-        // We support settimg bitmap through ImageSource (e.g. Bitmap).
+        // We support setting bitmap through ImageSource (e.g. Bitmap).
         if (uri == null || uri.trim() == "") {
             this.setImageBitmap(null);
         }
@@ -194,6 +194,13 @@ public class ImageView extends android.widget.ImageView implements BitmapOwner {
 
     @Override
     public void setImageBitmap(Bitmap bm) {
+        Fetcher fetcher = Fetcher.getInstance(this.getContext());
+        // if we have existing bitmap from uri notify fetcher that this bitmap is not shown in this ImageView instance.
+        // This is needed so that fetcher inner cache could reuse the bitmap only when no other ImageView shows it.
+        if (mUseCache && mUri != null && mBitmap != null && fetcher != null) {
+            fetcher.removeBitmap(mUri);
+        }
+
         super.setImageBitmap(bm);
         this.mBitmap = bm;
     }


### PR DESCRIPTION
…ap have been requested/shown.

Bitmap is put in reusable queue only if this bitmap reference counter is 0/null.
This prevents an issue where one big bitmap is added to cache but it exceeds cache limit so it is removed immediately from cache (LRU internals) and marked as reusable.

Fix https://github.com/NativeScript/NativeScript/issues/3747