### PR TITLE
When don’t keep activities is on all images are unloaded then on app …

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Image/Cache.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Image/Cache.java
@@ -192,7 +192,7 @@ public class Cache {
             memValue = mMemoryCache.get(data);
             if (memValue != null) {
                 Integer count = mMemoryCacheUsage.get(data);
-                mMemoryCacheUsage.put(data, count + 1);
+                mMemoryCacheUsage.put(data, count == null ? 1 : count + 1);
             }
         }
 


### PR DESCRIPTION
…resume it is possible to request image from cache but that image is not shown anywhere so it is not in the memoryCacheUsage