### PR TITLE
Fix GridLayout recycling

### DIFF
--- a/android/widgets/build.gradle
+++ b/android/widgets/build.gradle
@@ -11,7 +11,7 @@ def computeCompileSdkVersion () {
         return compileSdk
     }
     else {
-        return 23
+        return 25
     }
 }
 
@@ -29,7 +29,7 @@ def computeTargetSdkVersion() {
         return targetSdk
     }
     else {
-        return 23
+        return 25
     }
 }
 

--- a/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
@@ -522,24 +522,20 @@ class MeasureHelper {
     }
 
     public void setInfinityWidth(boolean value) {
-        if (this.infinityWidth != value) {
-            this.infinityWidth = value;
+        this.infinityWidth = value;
 
-            for (int i = 0, size = this.columns.size(); i < size; i++) {
-                ItemGroup columnGroup = this.columns.get(i);
-                columnGroup.setIsLengthInfinity(value);
-            }
+        for (int i = 0, size = this.columns.size(); i < size; i++) {
+            ItemGroup columnGroup = this.columns.get(i);
+            columnGroup.setIsLengthInfinity(value);
         }
     }
 
     public void setInfinityHeight(boolean value) {
-        if (this.infinityHeight != value) {
-            this.infinityHeight = value;
+        this.infinityHeight = value;
 
-            for (int i = 0, size = this.rows.size(); i < size; i++) {
-                ItemGroup rowGroup = this.rows.get(i);
-                rowGroup.setIsLengthInfinity(value);
-            }
+        for (int i = 0, size = this.rows.size(); i < size; i++) {
+            ItemGroup rowGroup = this.rows.get(i);
+            rowGroup.setIsLengthInfinity(value);
         }
     }
 


### PR DESCRIPTION
When GridLayout is recycled some internal states are not invalidated correctly