### PR TITLE
chore(travis-ci): suppress sdkmanager's output from log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ osx_image: xcode8.3
 install:
   - brew update
   - brew cask install android-sdk
-  - yes | sdkmanager "platforms;android-23"
-  - yes | sdkmanager "build-tools;23.0.3"
-  - yes | sdkmanager "extras;android;m2repository"
+  # Suppress output of sdkmanager to keep log under the 4MB limit of travis-ci
+  - yes | sdkmanager "platforms;android-23" >/dev/null
+  - yes | sdkmanager "build-tools;23.0.3" >/dev/null
+  - yes | sdkmanager "extras;android;m2repository" >/dev/null
 before_script:
   - export ANDROID_HOME=/usr/local/share/android-sdk
 script: ./build.sh $PACKAGE_VERSION


### PR DESCRIPTION
Recently, sdkmanager started to print a status bar to the console, which is increasing the size of the log above 4MB. 4MB is the limit at which travis-ci kills a job. This PR suppresses sdkmanager's stdout from the log to avoid that issue.

