### PR TITLE
feat(view-pager-android): add TabViewPager with switchable paging

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/TabViewPager.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/TabViewPager.java
@@ -1,0 +1,60 @@
+/**
+ * 
+ */
+package org.nativescript.widgets;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.MotionEvent;
+import android.view.KeyEvent;
+
+// See this thread for more information https://stackoverflow.com/questions/9650265
+public class TabViewPager extends ViewPager {
+    private boolean swipePageEnabled = true;
+
+    public TabViewPager(Context context) {
+        super(context);
+    }
+
+    public TabViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public void setSwipePageEnabled(boolean enabled) {
+        this.swipePageEnabled = enabled;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+        if (this.swipePageEnabled) {
+            return super.onInterceptTouchEvent(event);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (this.swipePageEnabled) {
+            return super.onTouchEvent(event);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean executeKeyEvent(KeyEvent event) {
+        if (this.swipePageEnabled) {
+            return super.executeKeyEvent(event);
+        }
+
+        return false;
+    }
+
+    @Override
+    public void setCurrentItem(int item) {
+        super.setCurrentItem(item, this.swipePageEnabled);
+    }
+}


### PR DESCRIPTION
Create `TabViewPager` layout that extends `ViewPager` and supports disabling swipe gestures over content area. 

`setSwipePageEnabled` - enables/disables touch interactions and overrides the lateral motion transition between views when disabled. _[See Android design guidelines for bottom navigation](https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-behavior)_

**_NOTE: `TabViewPager` is required since the `TabView` control for android in tns-core-modules should support top/bottom tab items positioning._**
