### PR TITLE
feat(tabview):improve tabview tab item title layout Implements #5439

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/TabLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/TabLayout.java
@@ -66,7 +66,7 @@ public class TabLayout extends HorizontalScrollView {
     private static final int TITLE_OFFSET_DIPS = 24;
     private static final int TAB_VIEW_PADDING_DIPS = 16;
     private static final int TAB_VIEW_TEXT_SIZE_SP = 12;
-    private static final int TEXT_MAX_WIDHT = 180;
+    private static final int TEXT_MAX_WIDTH = 180;
     private static final int SMALL_MIN_HEIGHT = 48;
     private static final int LARGE_MIN_HEIGHT = 72;
 
@@ -240,7 +240,7 @@ public class TabLayout extends HorizontalScrollView {
 
         TextView textView = new TextView(context);
         textView.setGravity(Gravity.CENTER);
-        textView.setMaxWidth((int) (TEXT_MAX_WIDHT * density));
+        textView.setMaxWidth((int) (TEXT_MAX_WIDTH * density));
         textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TAB_VIEW_TEXT_SIZE_SP);
         textView.setTypeface(Typeface.DEFAULT_BOLD);
         textView.setEllipsize(TextUtils.TruncateAt.END);

--- a/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
@@ -21,9 +21,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -86,6 +84,8 @@ class TabStrip extends LinearLayout {
 
         // Default selected color is the same as mTabTextColor
         mSelectedTabTextColor = mTabTextColor;
+
+        setMeasureWithLargestChildEnabled(true);
     }
 
     void setCustomTabColorizer(TabLayout.TabColorizer customTabColorizer) {


### PR DESCRIPTION
Implements https://github.com/NativeScript/NativeScript/issues/5439

Proposed improvement (measure with largest child) results in the following layouts (all tabviews have 5 tab items -- the "original" layouts can be found in https://github.com/NativeScript/NativeScript/issues/5439):
![screenshot_1519050775](https://user-images.githubusercontent.com/2650247/36385830-70e7d144-159c-11e8-97a8-3ff8a66438a3.png)

![screenshot_1519051551](https://user-images.githubusercontent.com/2650247/36385848-7ea014d6-159c-11e8-8192-56e788a9dff4.png)

![screenshot_1519050820](https://user-images.githubusercontent.com/2650247/36385860-8866db80-159c-11e8-81db-dba50af6e19c.png)
