### PR TITLE
fix: removed stacktrace printing when result error is set

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -561,7 +561,6 @@ public class Async
 				}
 				catch (Exception e) // TODO: Catch all exceptions?
 				{
-					e.printStackTrace();
 					result.error = e;
 
 					return result;


### PR DESCRIPTION
We don't need the stack trace to be printed when we return the exception in the result.error as it will be returned in the reject callback.

Fixes https://github.com/NativeScript/tns-core-modules-widgets/issues/118.