### PR TITLE
fix(layout-params): respect width/height properties when using percentages

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/CommonLayoutParams.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/CommonLayoutParams.java
@@ -118,7 +118,7 @@ public class CommonLayoutParams extends FrameLayout.LayoutParams {
         int verticalGravity = gravity & Gravity.VERTICAL_GRAVITY_MASK;
 
         // If we have explicit height and gravity is FILL we need to be centered otherwise our explicit height won't be taken into account.
-        if (lp.height >= 0 && verticalGravity == Gravity.FILL_VERTICAL) {
+        if ((lp.height >= 0 || lp.heightPercent >= 0) && verticalGravity == Gravity.FILL_VERTICAL) {
             verticalGravity = Gravity.CENTER_VERTICAL;
         }
 
@@ -145,7 +145,7 @@ public class CommonLayoutParams extends FrameLayout.LayoutParams {
         int horizontalGravity = Gravity.getAbsoluteGravity(gravity, child.getLayoutDirection()) & Gravity.HORIZONTAL_GRAVITY_MASK;
 
         // If we have explicit width and gravity is FILL we need to be centered otherwise our explicit width won't be taken into account.
-        if (lp.width >= 0 && horizontalGravity == Gravity.FILL_HORIZONTAL) {
+        if ((lp.width >= 0 || lp.widthPercent >= 0) && horizontalGravity == Gravity.FILL_HORIZONTAL) {
             horizontalGravity = Gravity.CENTER_HORIZONTAL;
         }
 


### PR DESCRIPTION
__The problem:__ `width/height` applied to ListView itemTemplate are reseting (not applied) after scrolling up and down the ListView. 

_Percentages are taken into account inside `onMeasure` (see `adjustChildrenLayoutParams` method calls for more reference) and restored at the __end__ of `OnLayout` to their original values (see `restoreOriginalParams`)._

_`OnMeasure` will be executed for every `LayoutBase` for the visible ListView items. Since we are recycling the view, used for a specific template, no further views will be created (only reused). `OnMeasure` won't be called for any of the reused views anymore and the percentages width/height will be used with their original values (NOT_SET) inside `OnLayout` method._

__The solution:__ Make an additional check whether `heightPercent`/`widthPercent` is set when setting the current child `gravity`. 

Fix: https://github.com/NativeScript/NativeScript/issues/6018