### PR TITLE
feat: Add Gzip ability to Android http

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -303,7 +303,7 @@ public class Async
 				{
 					String key = pair.key.toString();
 					connection.addRequestProperty(key, pair.value.toString());
-					if (key.toLowerCase().contentEquals("Accept-Encoding")) {
+					if (key.toLowerCase().contentEquals("accept-encoding")) {
 						hasAcceptHeader = true;
 					}
 				}

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -29,6 +29,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
 
 public class Async
 {
@@ -302,7 +303,7 @@ public class Async
 				{
 					String key = pair.key.toString();
 					connection.addRequestProperty(key, pair.value.toString());
-					if (key.contentEquals("Accept-Encoding")) {
+					if (key.toLowerCase().contentEquals("Accept-Encoding")) {
 						hasAcceptHeader = true;
 					}
 				}
@@ -400,7 +401,7 @@ public class Async
 					// In the event we don't have a null stream, and we have gzip as part of the encoding
 					// then we will use gzip to decode the stream
 					if (inStream != null) {
-						String encodingHeader = conn.getHeaderField("Content-Encoding");
+						String encodingHeader = connection.getHeaderField("Content-Encoding");
 						if (encodingHeader != null && encodingHeader.toLowerCase().contains("gzip")) {
 							inStream = new GZIPInputStream(inStream);
 						}

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -296,10 +296,20 @@ public class Async
 				{
 					return;
 				}
+				boolean hasAcceptHeader = false;
 
 				for (KeyValuePair pair : this.headers)
 				{
-					connection.addRequestProperty(pair.key.toString(), pair.value.toString());
+					String key = pair.key.toString();
+					connection.addRequestProperty(key, pair.value.toString());
+					if (key.contentEquals("Accept-Encoding")) {
+						hasAcceptHeader = true;
+					}
+				}
+
+				// If the user hasn't added an Accept-Encoding header, we add gzip as something we accept
+				if (!hasAcceptHeader) {
+					connection.addRequestProperty("Accept-Encoding", "gzip");
 				}
 			}
 
@@ -387,6 +397,14 @@ public class Async
 				else
 				{
 					inStream = connection.getInputStream();
+					// In the event we don't have a null stream, and we have gzip as part of the encoding
+					// then we will use gzip to decode the stream
+					if (inStream != null) {
+						String encodingHeader = conn.getHeaderField("Content-Encoding");
+						if (encodingHeader != null && encodingHeader.toLowerCase().contains("gzip")) {
+							inStream = new GZIPInputStream(inStream);
+						}
+					}
 				}
 
 				if (inStream == null)


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla). 
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Gzip encoding can cause http data to be unreadable.  Some servers send gzip by default; which then cause http to always fail to them.

## What is the new behavior?
Gzip is now an acceptable encoding method, and will be used by default if no other encoding header is sent to server to allow the server to default to gzip and save bandwidth.

Fixes/Implements/Closes #[Issue Number].
Several issues (over the years) in the main NativeScript repo.
https://github.com/NativeScript/NativeScript/issues/3652
https://github.com/NativeScript/NativeScript/issues/1314

Breaking Changes:
None

Migration steps:
None
