### PR TITLE
fix: Clear the child of the saved specs before clearing them

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
@@ -226,7 +226,7 @@ public class GridLayout extends LayoutBase {
     }
 
     private void removeFromMap(View child) {
-        this.map.get(child).child = null;;
+        this.map.get(child).child = null;
         this.map.remove(child);
     }
 

--- a/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java
@@ -226,6 +226,7 @@ public class GridLayout extends LayoutBase {
     }
 
     private void removeFromMap(View child) {
+        this.map.get(child).child = null;;
         this.map.remove(child);
     }
 
@@ -374,7 +375,7 @@ class MeasureSpecs {
 
     public boolean measured = false;
 
-    public final View child;
+    public View child;
     private ItemSpec column;
     private ItemSpec row;
     private int columnIndex;


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla). 
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
After adding a NativeScript `View` manually by calling `_addView()` in `RadListView`, calling `_removeView()` does not clear all of the references to that `View` and causes memory leak.

## What is the new behavior?
Calling `_removeView()` after manually adding a `View` via `_addView()` does not cause any `View` to be retained in the memory.

Fixes/Implements/Closes #[Issue Number].

Related to issue: https://github.com/telerik/nativescript-ui-feedback/issues/748

