### PR TITLE
fix: add support for gzipped content in http error stream

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -388,29 +388,23 @@ public class Async
 			{
 				int contentLength = connection.getContentLength();
 
-				InputStream inStream;
-				if (this.statusCode >= 400)
-				{
-					inStream = connection.getErrorStream();
-				}
-				else
-				{
-					inStream = connection.getInputStream();
-					// In the event we don't have a null stream, and we have gzip as part of the encoding
-					// then we will use gzip to decode the stream
-					if (inStream != null) {
-						String encodingHeader = connection.getHeaderField("Content-Encoding");
-						if (encodingHeader != null && encodingHeader.toLowerCase().contains("gzip")) {
-							inStream = new GZIPInputStream(inStream);
-						}
-					}
-				}
+				InputStream inStream =
+					this.statusCode >= 400
+						? connection.getErrorStream()
+						: connection.getInputStream();
 
 				if (inStream == null)
 				{
 					// inStream is null when receiving status code 401 or 407
 					// see this thread for more information http://stackoverflow.com/a/24986433
 					return;
+				}
+
+				// In the event we don't have a null stream, and we have gzip as part of the encoding
+				// then we will use gzip to decode the stream
+				String encodingHeader = connection.getHeaderField("Content-Encoding");
+				if (encodingHeader != null && encodingHeader.toLowerCase().contains("gzip")) {
+					inStream = new GZIPInputStream(inStream);
 				}
 
 				openedStreams.push(inStream);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.

  The solution looked trivial, so I decided to apply anyways.

- [x] You have signed the [CLA](http://www.nativescript.org/cla). 
- [x] All existing tests are passing
- [ ] Tests for the changes are included

  It didn't had tests, so I couldn't add it just for this change.

## What is the current behavior?
When the HTTP server responded with an error (statusCode >= 400),
the readResponseStream didn't decode the inStream as gzip even if
the request sended had the Content-Encoding header.

## What is the new behavior?
The new behavior is always test for Content-Header existance and it is equals to gzip even if
reading an error response stream.

Fixes/Implements/Closes #[Issue Number].

My fix moves the code that parses Content-Encoded header and
decodes gzipped body out the test to get the input stream to the
point where we are certain that we have a inStream that we can
decode


