### PR TITLE
feat(tabview): add tab-selected listener

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/OnTabSelectedListener.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/OnTabSelectedListener.java
@@ -1,0 +1,5 @@
+package org.nativescript.widgets;
+
+public interface OnTabSelectedListener {
+    void onTabSelected(int tabIndex);
+}

--- a/android/widgets/src/main/java/org/nativescript/widgets/TabViewPager.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/TabViewPager.java
@@ -6,13 +6,14 @@ package org.nativescript.widgets;
 import android.content.Context;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
-import android.view.View;
 import android.view.MotionEvent;
 import android.view.KeyEvent;
 
 // See this thread for more information https://stackoverflow.com/questions/9650265
 public class TabViewPager extends ViewPager {
     private boolean swipePageEnabled = true;
+
+    private OnTabSelectedListener mOnTabSelectedListener;
 
     public TabViewPager(Context context) {
         super(context);
@@ -22,10 +23,13 @@ public class TabViewPager extends ViewPager {
         super(context, attrs);
     }
 
+    public void setOnTabSelectedListener(OnTabSelectedListener listener) {
+        mOnTabSelectedListener = listener;
+    }
+
     public void setSwipePageEnabled(boolean enabled) {
         this.swipePageEnabled = enabled;
     }
-
     @Override
     public boolean onInterceptTouchEvent(MotionEvent event) {
         if (this.swipePageEnabled) {
@@ -55,6 +59,10 @@ public class TabViewPager extends ViewPager {
 
     @Override
     public void setCurrentItem(int item) {
+        if (this.mOnTabSelectedListener != null) {
+            this.mOnTabSelectedListener.onTabSelected(item);
+        }
+
         super.setCurrentItem(item, this.swipePageEnabled);
     }
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla). 
- [x] All existing tests are passing
- [ ] Tests for the changes are included

Helps implement https://github.com/NativeScript/NativeScript/issues/6095
PR for above issue, which uses the new listener: https://github.com/NativeScript/NativeScript/pull/6239

This simply adds a tab-selected listener to the org.nativescript.widgets.TabViewPager, which helps implement https://github.com/NativeScript/NativeScript/issues/6095
This was necessary on Android, since I could not otherwise detect when the user taps the current tab.
