### PR TITLE
refactor: remove obsolete ViewHelper.setBackground method

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/ViewHelper.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/ViewHelper.java
@@ -528,13 +528,5 @@ public class ViewHelper {
             textView.setLetterSpacing(value);
         }
     }
-
-    public static void setBackground(android.view.View view, android.graphics.drawable.Drawable background) {
-        if (version >= 16) {
-            view.setBackground(background);
-        } else {
-            view.setBackgroundDrawable(background);
-        }
-    }
 }
     


### PR DESCRIPTION
We are no longer supporting API levels < 16 so this polyfill is obsolete.