### PR TITLE
fix: error ... executing doInBackground() #138

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Image/DiskLruCache.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Image/DiskLruCache.java
@@ -254,7 +254,7 @@ public final class DiskLruCache implements Closeable {
     public static void deleteContents(File dir) throws IOException {
         File[] files = dir.listFiles();
         if (files == null) {
-            throw new IllegalArgumentException("not a directory: " + dir);
+            return;
         }
         for (File file : files) {
             if (file.isDirectory()) {


### PR DESCRIPTION
As requested in ST 1341351, this PR replaces the throw if `files` is null.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla). 
- [n/a] All existing tests are passing
- [n/a] Tests for the changes are included

## What is the current behavior?
Crashes as per #138 

## What is the new behavior?
As requested in ST 1341351, this PR replaces the throw if `files` is null.

BREAKING CHANGES:
None.

Migration steps:
None.

