### PR TITLE
refactor(Async): update onError of CompleteCallback interface

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -56,7 +56,7 @@ public class Async {
     public interface CompleteCallback {
         void onComplete(Object result, Object tag);
 
-        void onError(Object tag, String error);
+        void onError(String error, Object tag);
     }
 
     static class PriorityThreadFactory implements ThreadFactory {
@@ -194,7 +194,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.context);
                 } else {
-                    this.callback.onError(this.context, "DownloadImageTask returns no result.");
+                    this.callback.onError("DownloadImageTask returns no result.", this.context);
                 }
             }
         }
@@ -227,7 +227,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId, "LoadImageFromResourceTask returns no result.");
+                    this.callback.onError("LoadImageFromResourceTask returns no result.", this.requestId);
                 }
             }
         }
@@ -250,7 +250,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId, "LoadImageFromFileTask returns no result.");
+                    this.callback.onError("LoadImageFromFileTask returns no result.", this.requestId);
                 }
             }
         }
@@ -274,7 +274,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId, "LoadImageFromBase64StringTask returns no result.");
+                    this.callback.onError("LoadImageFromBase64StringTask returns no result.", this.requestId);
                 }
             }
         }
@@ -572,7 +572,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.context);
                 } else {
-                    this.callback.onError(this.context, "HttpRequestTask returns no result.");
+                    this.callback.onError("HttpRequestTask returns no result.", this.context);
                 }
             }
 

--- a/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -56,7 +56,7 @@ public class Async {
     public interface CompleteCallback {
         void onComplete(Object result, Object tag);
 
-        void onError(Object tag);
+        void onError(Object tag, String error);
     }
 
     static class PriorityThreadFactory implements ThreadFactory {
@@ -194,7 +194,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.context);
                 } else {
-                    this.callback.onError(this.context);
+                    this.callback.onError(this.context, "DownloadImageTask returns no result.");
                 }
             }
         }
@@ -227,7 +227,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId);
+                    this.callback.onError(this.requestId, "LoadImageFromResourceTask returns no result.");
                 }
             }
         }
@@ -250,7 +250,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId);
+                    this.callback.onError(this.requestId, "LoadImageFromFileTask returns no result.");
                 }
             }
         }
@@ -274,7 +274,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.requestId);
                 } else {
-                    this.callback.onError(this.requestId);
+                    this.callback.onError(this.requestId, "LoadImageFromBase64StringTask returns no result.");
                 }
             }
         }
@@ -572,7 +572,7 @@ public class Async {
                 if (result != null) {
                     this.callback.onComplete(result, this.context);
                 } else {
-                    this.callback.onError(this.context);
+                    this.callback.onError(this.context, "HttpRequestTask returns no result.");
                 }
             }
 


### PR DESCRIPTION
Include the error that occurs. A follow up on https://github.com/NativeScript/tns-core-modules-widgets/pull/147. CC: @NathanWalker

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If an error occurs, it gets lost.

## What is the new behavior?
<!-- Describe the changes. -->
If an error occurs, it gets passed to `onError()`.
