### PR TITLE
fix(ios): use legacy build system

### DIFF
--- a/ios/TNSWidgets/TNSWidgets.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/TNSWidgets/TNSWidgets.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fall back to legacy build system as a workaround to build iOS widgets with xcode10. At some point we should investigate what is failing with the default "new build system":

```
 ~/github/tns-core-modules-widgets ./build.ios.sh
Set exit on simple errors
Use dumb terminal
Clean dist
Build iOS
Set exit on simple errors
Build for iphonesimulator
Build for iphoneos
Build fat framework at TNSWidgets/build/TNSWidgets.framework
fatal error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't open input file: TNSWidgets/build/Release-iphonesimulator/TNSWidgets.framework/TNSWidgets (No such file or directory)
```