### PR TITLE
fix(Android): ExifInterface to use support lib

### DIFF
--- a/android/widgets/build.gradle
+++ b/android/widgets/build.gradle
@@ -62,6 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:exifinterface:' + computeSupportVersion()
     implementation 'com.android.support:support-v4:' + computeSupportVersion()
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla). 
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

Android apps can become unstable due to old usage of error prone ExifInterface class:
https://stackoverflow.com/a/44246248/2192332
```
02-06 18:55:03.396 10629 10629 W ExifInterface: Invalid image: ExifInterface got an unsupported image format file(ExifInterface supports JPEG and some RAW image formats only) or a corrupted JPEG file to ExifInterface.
02-06 18:55:03.396 10629 10629 W ExifInterface: java.io.IOException: Invalid marker: 89
02-06 18:55:03.396 10629 10629 W ExifInterface: 	at android.media.ExifInterface.getJpegAttributes(ExifInterface.java:1885)
02-06 18:55:03.396 10629 10629 W ExifInterface: 	at android.media.ExifInterface.loadAttributes(ExifInterface.java:1517)
02-06 18:55:03.396 10629 10629 W ExifInterface: 	at android.media.ExifInterface.<init>(ExifInterface.java:1216)
02-06 18:55:03.396 10629 10629 W ExifInterface: 	at org.nativescript.widgets.image.Fetcher.getExifInterface(Fetcher.java:402)
02-06 18:55:03.396 10629 10629 W ExifInterface: 	at org.nativescript.widgets.image.Fetcher.decodeSampledBitmapFromResource(Fetcher.java:392)
```

## What is the new behavior?

Android apps will remain stable.

Related: https://github.com/NativeScript/NativeScript/pull/6868

