### PR TITLE
fix(FlexboxLayout): issue #6156 and replace auto RTL detected by manual

### DIFF
--- a/android/widgets/src/main/java/org/nativescript/widgets/FlexboxLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/FlexboxLayout.java
@@ -119,7 +119,7 @@ public class FlexboxLayout extends ViewGroup {
      * The default value is {@link #FLEX_DIRECTION_ROW}.
      */
     private int mFlexDirection = FLEX_DIRECTION_ROW;
-
+    
 
     @IntDef({FLEX_WRAP_NOWRAP, FLEX_WRAP_WRAP, FLEX_WRAP_WRAP_REVERSE})
     @Retention(RetentionPolicy.SOURCE)
@@ -290,7 +290,20 @@ public class FlexboxLayout extends ViewGroup {
     private SparseIntArray mOrderCache;
 
     private List<FlexLine> mFlexLines = new ArrayList<>();
-
+    
+    /**
+     *  force change RTL direction
+     */
+    
+    private boolean mIsRtl = false;
+    public setRtl(boolean rtl) {
+        mIsRtl = rtl;
+    }
+    
+    public boolean getRtl() {
+        return mIsRtl;
+    }
+    
     /**
      * Holds the 'frozen' state of children during measure. If a view is frozen it will no longer
      * expand or shrink regardless of flexGrow/flexShrink. Items are indexed by the child's
@@ -1557,25 +1570,21 @@ public class FlexboxLayout extends ViewGroup {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         int layoutDirection = ViewCompat.getLayoutDirection(this);
-        boolean isRtl;
+        boolean isRtl = mIsRtl;
         switch (mFlexDirection) {
             case FLEX_DIRECTION_ROW:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 layoutHorizontal(isRtl, left, top, right, bottom);
                 break;
             case FLEX_DIRECTION_ROW_REVERSE:
-                isRtl = layoutDirection != ViewCompat.LAYOUT_DIRECTION_RTL;
                 layoutHorizontal(isRtl, left, top, right, bottom);
                 break;
             case FLEX_DIRECTION_COLUMN:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     isRtl = !isRtl;
                 }
                 layoutVertical(isRtl, false, left, top, right, bottom);
                 break;
             case FLEX_DIRECTION_COLUMN_REVERSE:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     isRtl = !isRtl;
                 }
@@ -2016,25 +2025,22 @@ public class FlexboxLayout extends ViewGroup {
         }
 
         int layoutDirection = ViewCompat.getLayoutDirection(this);
-        boolean isRtl;
+        boolean isRtl = mIsRtl;
         boolean fromBottomToTop = false;
         switch (mFlexDirection) {
             case FLEX_DIRECTION_ROW:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     fromBottomToTop = true;
                 }
                 drawDividersHorizontal(canvas, isRtl, fromBottomToTop);
                 break;
             case FLEX_DIRECTION_ROW_REVERSE:
-                isRtl = layoutDirection != ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     fromBottomToTop = true;
                 }
                 drawDividersHorizontal(canvas, isRtl, fromBottomToTop);
                 break;
             case FLEX_DIRECTION_COLUMN:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     isRtl = !isRtl;
                 }
@@ -2042,7 +2048,6 @@ public class FlexboxLayout extends ViewGroup {
                 drawDividersVertical(canvas, isRtl, fromBottomToTop);
                 break;
             case FLEX_DIRECTION_COLUMN_REVERSE:
-                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     isRtl = !isRtl;
                 }

--- a/android/widgets/src/main/java/org/nativescript/widgets/FlexboxLayout.java
+++ b/android/widgets/src/main/java/org/nativescript/widgets/FlexboxLayout.java
@@ -296,7 +296,7 @@ public class FlexboxLayout extends ViewGroup {
      */
     
     private boolean mIsRtl = false;
-    public setRtl(boolean rtl) {
+    public void setRtl(boolean rtl) {
         mIsRtl = rtl;
     }
     


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla). 
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I replaced auto RTL detected by manual detected

## What is the new behavior?
<!-- Describe the changes. -->
I replaced auto RTL detected by manual detected
new you can change direction FlexboxLayout ( by default is LTR ) by `setRtl(boolean rtl)`
Fixes #6156.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:

- add new variable named `mIsRtl` by default `false`
- add getter and setter for RTL value.
- replace device RTL detected by `mIsRtl`

<!-- 
[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

